### PR TITLE
Fix for grid_sample_gradfix and conv2d_gradfix on pytorch 1.11

### DIFF
--- a/torch_utils/ops/grid_sample_gradfix.py
+++ b/torch_utils/ops/grid_sample_gradfix.py
@@ -12,6 +12,7 @@ Only works on 2D images and assumes
 `mode='bilinear'`, `padding_mode='zeros'`, `align_corners=False`."""
 
 import torch
+from pkg_resources import parse_version
 
 # pylint: disable=redefined-builtin
 # pylint: disable=arguments-differ
@@ -20,6 +21,7 @@ import torch
 #----------------------------------------------------------------------------
 
 enabled = False  # Enable the custom op by setting this to true.
+_use_pytorch_1_11_api = parse_version(torch.__version__) >= parse_version('1.11.0a') # Allow prerelease builds of 1.11
 
 #----------------------------------------------------------------------------
 
@@ -56,7 +58,11 @@ class _GridSample2dBackward(torch.autograd.Function):
     @staticmethod
     def forward(ctx, grad_output, input, grid):
         op = torch._C._jit_get_operation('aten::grid_sampler_2d_backward')
-        grad_input, grad_grid = op(grad_output, input, grid, 0, 0, False)
+        if _use_pytorch_1_11_api:
+            output_mask = (ctx.needs_input_grad[1], ctx.needs_input_grad[2])
+            grad_input, grad_grid = op(grad_output, input, grid, 0, 0, False, output_mask)
+        else:
+            grad_input, grad_grid = op(grad_output, input, grid, 0, 0, False)
         ctx.save_for_backward(grid)
         return grad_input, grad_grid
 

--- a/torch_utils/ops/grid_sample_gradfix.py
+++ b/torch_utils/ops/grid_sample_gradfix.py
@@ -22,6 +22,7 @@ from pkg_resources import parse_version
 
 enabled = False  # Enable the custom op by setting this to true.
 _use_pytorch_1_11_api = parse_version(torch.__version__) >= parse_version('1.11.0a') # Allow prerelease builds of 1.11
+_use_pytorch_1_12_api = parse_version(torch.__version__) >= parse_version('1.12.0a') # Allow prerelease builds of 1.12
 
 #----------------------------------------------------------------------------
 
@@ -58,6 +59,8 @@ class _GridSample2dBackward(torch.autograd.Function):
     @staticmethod
     def forward(ctx, grad_output, input, grid):
         op = torch._C._jit_get_operation('aten::grid_sampler_2d_backward')
+        if _use_pytorch_1_12_api:
+            op = op[0]
         if _use_pytorch_1_11_api:
             output_mask = (ctx.needs_input_grad[1], ctx.needs_input_grad[2])
             grad_input, grad_grid = op(grad_output, input, grid, 0, 0, False, output_mask)


### PR DESCRIPTION
I was receiving the below error when training which seems to be a result of a backwards-incompatible change in PyTorch 1.11.0, as pointed out in [PyTorch issue #75018](https://github.com/pytorch/pytorch/issues/75018#issuecomment-1087499109) regarding StyleGAN3.
```
Traceback (most recent call last):
  File "/home/ubuntu/stylegan-xl/train.py", line 336, in <module>
    main()  # pylint: disable=no-value-for-parameter
  File "/home/ubuntu/miniconda3/envs/sgxl/lib/python3.9/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/home/ubuntu/miniconda3/envs/sgxl/lib/python3.9/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/home/ubuntu/miniconda3/envs/sgxl/lib/python3.9/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/ubuntu/miniconda3/envs/sgxl/lib/python3.9/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/ubuntu/stylegan-xl/train.py", line 321, in main
    launch_training(c=c, desc=desc, outdir=opts.outdir, dry_run=opts.dry_run)
  File "/home/ubuntu/stylegan-xl/train.py", line 104, in launch_training
    subprocess_fn(rank=0, c=c, temp_dir=temp_dir)
  File "/home/ubuntu/stylegan-xl/train.py", line 49, in subprocess_fn
    training_loop.training_loop(rank=rank, **c)
  File "/home/ubuntu/stylegan-xl/training/training_loop.py", line 339, in training_loop
    loss.accumulate_gradients(phase=phase.name, real_img=real_img, real_c=real_c, gen_z=gen_z, gen_c=gen_c, gain=phase.interval, cur_nimg=cur_nimg)
  File "/home/ubuntu/stylegan-xl/training/loss.py", line 121, in accumulate_gradients
    loss_Gmain.backward()
  File "/home/ubuntu/miniconda3/envs/sgxl/lib/python3.9/site-packages/torch/_tensor.py", line 522, in backward
    torch.autograd.backward(
  File "/home/ubuntu/miniconda3/envs/sgxl/lib/python3.9/site-packages/torch/autograd/__init__.py", line 266, in backward
    Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
  File "/home/ubuntu/miniconda3/envs/sgxl/lib/python3.9/site-packages/torch/autograd/function.py", line 289, in apply
    return user_fn(self, *args)
  File "/home/ubuntu/stylegan-xl/torch_utils/ops/conv2d_gradfix.py", line 144, in backward
    grad_weight = Conv2dGradWeight.apply(grad_output, input)
  File "/home/ubuntu/miniconda3/envs/sgxl/lib/python3.9/site-packages/torch/autograd/function.py", line 553, in apply
    return super().apply(*args, **kwargs)  # type: ignore[misc]
  File "/home/ubuntu/stylegan-xl/torch_utils/ops/conv2d_gradfix.py", line 173, in forward
    return torch._C._jit_get_operation(name)(weight_shape, grad_output, input, padding, stride, dilation, groups, *flags)
TypeError: 'tuple' object is not callable
```
@jannehellsten pushed a change to StyleGAN3 to fix this issue according to their [comment](https://github.com/pytorch/pytorch/issues/75018#issuecomment-1106591595) on the aforementioned PyTorch issue.

After applying these same changes locally to conv2d_gradfix.py and grid_sample_gradfix.py in stylegan-xl, I can confirm that the model is training smoothly on my custom dataset.